### PR TITLE
Fix fpng.Write on Windows paths containing non-ASCII characters

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -5,8 +5,11 @@
 #include <VapourSynth4.h>
 #include <VSHelper4.h>
 
-#include <string>
+#include <cstdio>
+#include <cstdlib>
 #include <memory>
+#include <string>
+#include <vector>
 
 #ifdef _WIN32
 #include "vsutf16.h"
@@ -73,6 +76,29 @@ static bool fileExists(const std::string &filename) {
     if (f)
         fclose(f);
     return !!f;
+}
+
+static bool writeBinaryFile(const std::string &filename, const std::vector<uint8_t> &data) {
+#ifdef _WIN32
+    // Windows CRT narrow fopen* does not reliably accept UTF-8 file paths.
+    FILE * f = _wfopen(utf16_from_utf8(filename).c_str(), L"wb");
+#else
+    FILE * f = fopen(filename.c_str(), "wb");
+#endif
+    if (!f)
+        return false;
+
+    bool ok = fwrite(data.data(), 1, data.size(), f) == data.size();
+    ok = fclose(f) != EOF && ok;
+    return ok;
+}
+
+static bool encodeImageToFile(const std::string &filename, const void *image, uint32_t width, uint32_t height, uint32_t channelCount, uint32_t flags) {
+    std::vector<uint8_t> encoded;
+    if (!fpng::fpng_encode_image_to_memory(image, width, height, channelCount, encoded, flags))
+        return false;
+
+    return writeBinaryFile(filename, encoded);
 }
 
 //////////////////////////////////////////
@@ -154,7 +180,7 @@ static const VSFrame *VS_CC writeGetFrame(int n, int activationReason, void *ins
 
         p2p_pack_frame(&p, P2P_ALPHA_SET_ONE);
 
-        bool write_status = fpng::fpng_encode_image_to_file(filename.c_str(), imageBuffer, width, height, channelCount, d->compression);
+        bool write_status = encodeImageToFile(filename, imageBuffer, width, height, channelCount, d->compression);
 
         vsapi->freeFrame(alphaFrame);
         free(imageBuffer);

--- a/src/vsutf16.h
+++ b/src/vsutf16.h
@@ -25,10 +25,16 @@
 #include <windows.h>
 
 static std::wstring utf16_from_utf8(const std::string &str) {
-    int required_size = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
-    std::wstring wbuffer;
-    wbuffer.resize(required_size - 1);
-    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), static_cast<int>(str.size()), &wbuffer[0], required_size);
+    int required_size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), -1, nullptr, 0);
+    if (required_size <= 0)
+        return {};
+
+    std::wstring wbuffer(static_cast<size_t>(required_size), L'\0');
+    int written = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.c_str(), -1, wbuffer.data(), required_size);
+    if (written <= 0)
+        return {};
+
+    wbuffer.resize(static_cast<size_t>(written - 1));
     return wbuffer;
 }
 


### PR DESCRIPTION
# Problem

`fpng.Write` fails on Windows when the output directory path contains non-ASCII characters.

I reproduced this with a Chinese output directory. Writing to an ASCII-only directory succeeds, but writing to the same kind of path under a directory such as `test-output-中文` fails during `get_frame(0)` with:

```text
Write: Frame could not be written. Ensure that output path exists and is writable
```

No output PNG is created.

# Cause

The plugin already uses `_wfopen(utf16_from_utf8(...))` when checking whether a file exists on Windows, but the actual write path calls `fpng::fpng_encode_image_to_file(filename.c_str(), ...)`.

The vendored `fpng_encode_image_to_file()` implementation eventually uses narrow `fopen`/`fopen_s`. On Windows, those APIs do not reliably interpret UTF-8 paths, so paths containing non-ASCII characters can fail even when the directory exists and is writable.

There was also a small issue in the UTF-8 to UTF-16 helper: the destination buffer did not leave room for the terminating NUL while calling `MultiByteToWideChar`.

# Changes

This PR changes the write path to:

1. Encode the PNG into memory with `fpng_encode_image_to_memory()`.
2. Write the encoded bytes from the plugin layer.
3. Use `_wfopen(utf16_from_utf8(...), L"wb")` on Windows.
4. Keep normal `fopen(..., "wb")` behavior on non-Windows platforms.

It also makes `utf16_from_utf8()` validate UTF-8 input and allocate the UTF-16 buffer correctly.

# Verification

I built both the original plugin and the fixed plugin locally on Windows with the same VapourSynth R77 environment.

The original plugin fails when writing to the Chinese output directory:

```text
Write: Frame could not be written. Ensure that output path exists and is writable
```

The fixed plugin successfully writes:

```text
test-output-中文/frame000.png
```

I also verified that `overwrite=False` still correctly detects an existing file in a non-ASCII directory and leaves it untouched.
